### PR TITLE
Update gVisor to v0.0.0-20220920171436-4e7fd140e8d0 

### DIFF
--- a/cdc_ecm.go
+++ b/cdc_ecm.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/usbarmory/tamago/soc/nxp/usb"
 
-	"gvisor.dev/gvisor/pkg/buffer"
+	"gvisor.dev/gvisor/pkg/bufferv2"
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/link/channel"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
@@ -103,7 +103,7 @@ func (eth *NIC) ECMRx(out []byte, lastErr error) (_ []byte, err error) {
 
 	pkt := stack.NewPacketBuffer(stack.PacketBufferOptions{
 		ReserveHeaderBytes: len(hdr),
-		Payload:            buffer.NewWithData(payload),
+		Payload:            bufferv2.MakeWithData(payload),
 	})
 
 	copy(pkt.LinkHeader().Push(len(hdr)), hdr)
@@ -131,7 +131,7 @@ func (eth *NIC) ECMTx(_ []byte, lastErr error) (in []byte, err error) {
 	in = append(in, eth.Device...)
 	in = append(in, proto...)
 
-	for _, v := range pkt.Slices() {
+	for _, v := range pkt.AsSlices() {
 		in = append(in, v...)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/usbarmory/tamago v0.0.0-20220823080407-04f05cf2a5a3
-	gvisor.dev/gvisor v0.0.0-20220714043431-1868ba74ac26
+	gvisor.dev/gvisor v0.0.0-20220920171436-4e7fd140e8d0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,10 @@
 github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
 github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
-github.com/usbarmory/tamago v0.0.0-20220714104148-d5b7c14a0fbb h1:hMUTOoMrjgbP/Yjvy3SAyHFZ+W3v1cQTrvO09R1cqa8=
-github.com/usbarmory/tamago v0.0.0-20220714104148-d5b7c14a0fbb/go.mod h1:Lok79mjbJnhoBGqhX5cCUsZtSemsQF5FNZW+2R1dRr8=
 github.com/usbarmory/tamago v0.0.0-20220823080407-04f05cf2a5a3 h1:OgWngXmohy/sxTnHm7uStq0YlMkH0J+JY2HnBCv6fn0=
 github.com/usbarmory/tamago v0.0.0-20220823080407-04f05cf2a5a3/go.mod h1:Lok79mjbJnhoBGqhX5cCUsZtSemsQF5FNZW+2R1dRr8=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-gvisor.dev/gvisor v0.0.0-20220714043431-1868ba74ac26 h1:wJAPS+0X3oucN0xsgG8J9pCEu1fpu9azecrthIwr4dw=
-gvisor.dev/gvisor v0.0.0-20220714043431-1868ba74ac26/go.mod h1:TIvkJD0sxe8pIob3p6T8IzxXunlp6yfgktvTNp+DGNM=
+gvisor.dev/gvisor v0.0.0-20220920171436-4e7fd140e8d0 h1:8k7JH2hwOBM/c/XqZefFWTBCPk6QW7Qm4c2v5RUG4Ms=
+gvisor.dev/gvisor v0.0.0-20220920171436-4e7fd140e8d0/go.mod h1:D0iRe6RVONyvN6uEi/rqBtONyitX5GaHMDDbeMzwgiE=


### PR DESCRIPTION
Updates gVisor to latest release on `go` branch.
Includes local changes to migrate to `bufferv2` (since `buffer` has been removed).